### PR TITLE
Use claimRef to identify Volume Claims

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -275,7 +275,7 @@ async def get_rules(ctx):
 
 async def load_snapshots(ctx):
     r = await exec(ctx.gcloud.snapshots().list(project=ctx.config['gcloud_project']).execute)
-    return r['items']
+    return r.get('items', [])
 
 
 async def get_snapshots(ctx, reload_trigger):


### PR DESCRIPTION
This addresses a TODO in the code relating to behavior around volumes created by a PersistentVolumeClaim. The issue is that if a volume is created via a PersistentVolumeClaim, it will get created without the desired annotations since annotations don't get passed through.

To get around the problem, we can use the claimRef attribute of the PersistentVolume object to read from the PersistentVolumeClaim corresponding to the current volume allowing us to read any annotations supplied there.