### PR TITLE
Use thread for sync_get_rules

### DIFF
--- a/asyncutils.py
+++ b/asyncutils.py
@@ -52,25 +52,3 @@ async def combine_latest(defaults=None, **generators):
         current.update(value)
         yield current
 
-
-async def iterate_in_executor(sync_iter, *args):
-    """run_in_executor returns a future. But what if the function
-    we call is supposed to return values iteratively?
-    """
-    loop = asyncio.get_event_loop()
-    channel = Channel()
-    def forward_iter(*a):
-        try:
-            # TODO: We are looking for a solution to stop this
-            # if the channel is closed. Should this thread use it's
-            # own event loop where we can use await?
-            for value in sync_iter(*a):
-                asyncio.ensure_future(channel.put(value), loop=loop)
-        finally:
-            channel.close()
-    result = asyncio.get_event_loop().run_in_executor(None, forward_iter, *args)
-    async for item in channel:
-        yield item
-
-    # Any exceptions would be retrieved here
-    await result

--- a/daemon.py
+++ b/daemon.py
@@ -209,6 +209,10 @@ def rule_from_pv(volume, api, deltas_annotation_key, use_claim_name=False):
             volume.name, e)
         return
 
+    if deltas is None:
+        logger.error('Deltas defined by volume {} are None', volume.name)
+        return
+
     rule = Rule()
     rule.name = volume.name
     rule.namespace = volume.namespace

--- a/daemon.py
+++ b/daemon.py
@@ -6,6 +6,7 @@ backup expiration logic is already in tarsnapper and well tested.
 import os
 import sys
 import json
+import threading
 from datetime import datetime, timedelta
 import asyncio
 
@@ -19,7 +20,7 @@ from tarsnapper.expire import expire
 import pykube
 import pendulum
 import logbook
-from asyncutils import combine, combine_latest, iterate_in_executor, exec
+from asyncutils import combine_latest, exec
 
 
 # TODO: prevent a backup loop: A failsafe mechanism to make sure we
@@ -277,7 +278,25 @@ def sync_get_rules(ctx):
 
 
 async def get_rules(ctx):
-    async for item in iterate_in_executor(sync_get_rules, ctx):
+    channel = Channel()
+    loop = asyncio.get_event_loop()
+
+    def worker():
+        try:
+            for value in sync_get_rules(ctx):
+                asyncio.ensure_future(channel.put(value), loop=loop)
+        finally:
+            channel.close()
+
+    thread = threading.Thread(
+        target=worker,
+        name='get_rules',
+        daemon=True
+    )
+    thread.start()
+
+    async for item in channel:
+        logger.debug('item={}', item)
         yield ctx.config.get('rules') + item
 
 

--- a/daemon.py
+++ b/daemon.py
@@ -8,6 +8,8 @@ import sys
 import json
 from datetime import datetime, timedelta
 import asyncio
+
+import attr
 import confcollect
 from aiochannel import Channel, ChannelEmpty
 from googleapiclient import discovery
@@ -104,17 +106,18 @@ class Context:
         return compute
 
 
+@attr.s(init=False)
 class Rule:
     """A rule describes how and when to make backups.
     """
 
-    name = None
-    namespace = None
-    deltas = None
-    deltas_unparsed = None
-    gce_disk = None
-    gce_disk_zone = None
-    claim_name = None
+    name = attr.ib()
+    namespace = attr.ib()
+    deltas = attr.ib()
+    deltas_unparsed = attr.ib()
+    gce_disk = attr.ib()
+    gce_disk_zone = attr.ib()
+    claim_name = attr.ib()
 
     @property
     def pretty_name(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 google-api-python-client==1.5.4
+attrs==17.2.0
 pykube==0.14.0
 tarsnapper==0.4.0
 aiochannel==0.2.2


### PR DESCRIPTION
ThreadPoolExecutor is very hard to shut down, a 'simple' daemon Thread
seems to work great.

Added a dependency on [`attrs`](http://attrs.readthedocs.io/en/stable/), use it for `Rule` so that it can be conveniently logged.