### PR TITLE
ISO 8601 duration, snapshot labels, watch PVC, Kubernetes testing

### DIFF
--- a/k8s_snapshots/__main__.py
+++ b/k8s_snapshots/__main__.py
@@ -7,19 +7,19 @@ import confcollect
 import structlog
 
 import k8s_snapshots.config
-from k8s_snapshots.logconf import configure_logging
+from k8s_snapshots.logconf import configure_from_config
 from k8s_snapshots.core import daemon
 
 
 def main():
     config = k8s_snapshots.config.from_environ()
 
-    configure_logging(config)
+    configure_from_config(config)
 
     if config['debug']:
         sys.excepthook = debug_excepthook
 
-    # Late import to keep module-level get_logger after configure_logging
+    # Late import to keep module-level get_logger after configure_from_config
     _logger = structlog.get_logger(__name__)
 
     _logger.bind(

--- a/k8s_snapshots/config.py
+++ b/k8s_snapshots/config.py
@@ -5,11 +5,11 @@ import confcollect
 import pendulum
 import re
 import structlog
-from tarsnapper.config import ConfigError, parse_deltas
+from tarsnapper.config import ConfigError
 
 from k8s_snapshots import events
 from k8s_snapshots.errors import ConfigurationError
-from k8s_snapshots.rule import Rule
+from k8s_snapshots.rule import Rule, parse_deltas
 
 _logger = structlog.get_logger()
 
@@ -167,8 +167,6 @@ def read_volume_config() -> Dict:
 
         rule = Rule(
             name=name,
-            claim_name='',
-            namespace='',
             deltas=parse_deltas(deltas_str),
             gce_disk=name,
             gce_disk_zone=zone,

--- a/k8s_snapshots/config.py
+++ b/k8s_snapshots/config.py
@@ -35,6 +35,8 @@ DEFAULT_CONFIG = {
     #: This label will be set on all snapshots created by k8s-snapshots
     'snapshot_author_label': 'k8s-snapshots',
     'snapshot_author_label_key': 'created-by',
+    #: Number of seconds between Rule.HEARTBEAT events, ``0`` to disable.
+    'schedule_heartbeat_interval_seconds': 600,
     #: Turns debug mode on, not recommended in production
     'debug': False,
 }

--- a/k8s_snapshots/context.py
+++ b/k8s_snapshots/context.py
@@ -7,17 +7,13 @@ from googleapiclient import discovery
 from oauth2client.service_account import ServiceAccountCredentials
 from oauth2client.client import GoogleCredentials
 
-from k8s_snapshots.config import DEFAULT_CONFIG
-
 _logger = structlog.get_logger()
 
 
 class Context:
-
     def __init__(self, config=None):
         self.config = config
         self.kube = self.make_kubeclient()
-        self.gcloud = self.make_gclient()
 
     def make_kubeclient(self):
         cfg = None
@@ -44,7 +40,18 @@ class Context:
 
         return pykube.HTTPClient(cfg)
 
-    def make_gclient(self):
+    def gcloud(self, version: str='v1'):
+        """
+        Get a configured Google Compute API Client instance.
+
+        Note that the Google API Client is not threadsafe. Cache the instance locally
+        if you want to avoid OAuth overhead between calls.
+
+        Parameters
+        ----------
+        version
+            Compute API version
+        """
         SCOPES = 'https://www.googleapis.com/auth/compute'
         credentials = None
 
@@ -66,7 +73,7 @@ class Context:
 
         compute = discovery.build(
             'compute',
-            'v1',
+            version,
             credentials=credentials,
         )
         return compute

--- a/k8s_snapshots/core.py
+++ b/k8s_snapshots/core.py
@@ -1,221 +1,191 @@
 #!/usr/bin/env python3
 """Written in asyncio as a learning experiment. Python because the
 backup expiration logic is already in tarsnapper and well tested.
+
+TODO: prevent a backup loop: A failsafe mechanism to make sure we
+  don't create more than x snapshots per disk; in case something
+  is wrong with the code that loads the exsting snapshots from GCloud.
+TODO: Support http ping after every backup.
+TODO: Support loading configuration from a configmap.
+TODO: We could use a third party resource type, too.
 """
 import asyncio
-import aiohttp
-import re
-import threading
-from datetime import timedelta
-from typing import Dict, Iterable, Optional, List, Tuple
 
 import pendulum
 import pykube
 import structlog
 from aiochannel import Channel, ChannelEmpty
-from googleapiclient.discovery import Resource
-from tarsnapper.expire import expire
+from aiostream import stream
 
-from k8s_snapshots import errors, events
-from k8s_snapshots.asyncutils import combine_latest, run_in_executor
-# TODO: prevent a backup loop: A failsafe mechanism to make sure we
-#   don't create more than x snapshots per disk; in case something
-#   is wrong with the code that loads the exsting snapshots from GCloud.
-# TODO: Support http ping after every backup.
-# TODO: Support loading configuration from a configmap.
-# TODO: We could use a third party resource type, too.
+from k8s_snapshots import events
+from k8s_snapshots.asyncutils import combine_latest
 from k8s_snapshots.context import Context
-from k8s_snapshots.errors import AnnotationNotFound, AnnotationError
-from k8s_snapshots.rule import Rule, rule_from_pv
+from k8s_snapshots.errors import (
+    AnnotationNotFound,
+    AnnotationError,
+    UnsupportedVolume,
+    VolumeNotFound
+)
+from k8s_snapshots.kube import (
+    watch_resources,
+    get_resource_or_none
+)
+from k8s_snapshots.rule import rule_from_pv
+from k8s_snapshots.snapshot import (
+    make_backup,
+    get_snapshots,
+    determine_next_snapshot
+)
 
 _logger = structlog.get_logger()
 
 
-def filter_snapshots_by_rule(snapshots, rule) -> Iterable:
-    def match_disk(snapshot):
-        url_part = '/zones/{zone}/disks/{name}'.format(
-            zone=rule.gce_disk_zone, name=rule.gce_disk)
-        return snapshot['sourceDisk'].endswith(url_part)
-    return filter(match_disk, snapshots)
+async def volume_from_resource_event(
+        ctx: Context,
+        event
+) -> pykube.objects.PersistentVolume:
+    if isinstance(event.object, pykube.objects.PersistentVolume):
+        return event.object
+    elif isinstance(event.object, pykube.objects.PersistentVolumeClaim):
+        pvc = event.object
 
+        try:
+            volume_name = event.object.obj['spec']['volumeName']
+        except KeyError as exc:
+            raise VolumeNotFound(
+                'Could not get volume name from volume claim',
+                volume_claim=pvc.obj
+            ) from exc
 
-def parse_creation_timestamp(snapshot: Dict) -> pendulum.Pendulum:
-    return pendulum.parse(
-        snapshot['creationTimestamp']
-    ).in_timezone('utc')
-
-
-def determine_next_snapshot(snapshots, rules):
-    """
-    Given a list of snapshots, and a list of rules, determine the next snapshot
-    to be made.
-
-    Returns a 2-tuple (rule, target_datetime)
-    """
-    next_rule = None
-    next_timestamp = None
-
-    for rule in rules:
-        _log = _logger.new(rule=rule)
-        # Find all the snapshots that match this rule
-        snapshots_for_rule = filter_snapshots_by_rule(snapshots, rule)
-        # Rewrite the list to snapshot
-        snapshot_times = map(parse_creation_timestamp, snapshots_for_rule)
-        # Sort by timestamp
-        snapshot_times = sorted(snapshot_times, reverse=True)
-        snapshot_times = list(snapshot_times)
-
-        # There are no snapshots for this rule; create the first one.
-        if not snapshot_times:
-            next_rule = rule
-            next_timestamp = pendulum.now('utc') + timedelta(seconds=10)
-            _log.info(
-                events.Snapshot.SCHEDULED,
-                target=next_timestamp,
-                key_hints=['rule.name', 'target'],
+        volume = await get_resource_or_none(
+            ctx,
+            pykube.objects.PersistentVolume,
+            volume_name,
+        )  # type: pykube.objects.PersistentVolume
+        if volume is None:
+            raise VolumeNotFound(
+                f'Could not find volume with name {volume_name!r}',
+                volume_claim=pvc.obj,
             )
-            break
-
-        target = snapshot_times[0] + rule.deltas[0]
-        if not next_timestamp or target < next_timestamp:
-            next_rule = rule
-            next_timestamp = target
-
-    if next_rule is not None and next_timestamp is not None:
-        _logger.info(
-            events.Snapshot.SCHEDULED,
-            key_hints=['rule.name', 'target'],
-            target=next_timestamp,
-            rule=next_rule,
-        )
-
-    return next_rule, next_timestamp
+        return volume
 
 
-def sync_get_rules(ctx):
+async def rules_from_volumes(ctx):
     rules = {}
-    api = ctx.make_kubeclient()
 
     _logger.debug('volume-events.watch')
-    stream = pykube.objects.PersistentVolume.objects(api).watch().object_stream()
 
-    for event in stream:
-        volume_name = event.object.name
-        _log = _logger.new(
-            volume_name=volume_name,
-            volume_event_type=event.type,
-            volume=event.object.obj,
-        )
+    merged_stream = stream.merge(
+        watch_resources(ctx, pykube.objects.PersistentVolume),
+        watch_resources(ctx, pykube.objects.PersistentVolumeClaim)
+    )
 
-        _log.debug('volume-event.received')
+    async with merged_stream.stream() as merged_events:
 
-        if event.type == 'ADDED' or event.type == 'MODIFIED':
-            rule = None
+        async for event in merged_events:
+            _log_event = _logger.bind(
+                event_type=event.type,
+                event_object=event.object.obj,
+            )
+            _log_event.info(
+                events.VolumeEvent.RECEIVED,
+                key_hints=[
+                    'event_type',
+                    'event_object.metadata.name',
+                ],
+            )
             try:
-                rule = rule_from_pv(
-                    event.object,
-                    api,
-                    ctx.config.get('deltas_annotation_key'),
-                    use_claim_name=ctx.config.get('use_claim_name'))
-            except AnnotationNotFound as exc:
-                _log.info(
-                    events.Annotation.NOT_FOUND,
-                    key_hints=['volume.metadata.name'],
-                    exc_info=exc,
+                volume = await volume_from_resource_event(ctx, event)
+            except VolumeNotFound:
+                _log_event.exception(
+                    events.Volume.NOT_FOUND,
+                    key_hints=[
+                        'event_type',
+                        'event_object.metadata.name',
+                    ],
                 )
-            except AnnotationError:
-                _log.exception(
-                    events.Annotation.ERROR,
-                    key_hints=['volume.metadata.name']
-                )
+                continue
 
-            if rule:
+            volume_name = volume.name
+            _log = _logger.new(
+                volume_name=volume_name,
+                volume_event_type=event.type,
+                volume=volume.obj,
+            )
+
+            if event.type == 'ADDED' or event.type == 'MODIFIED':
+                rule = None
+                try:
+                    rule = await rule_from_pv(
+                        ctx,
+                        volume,
+                        ctx.config.get('deltas_annotation_key'),
+                        use_claim_name=ctx.config.get('use_claim_name'))
+                except AnnotationNotFound as exc:
+                    _log.info(
+                        events.Annotation.NOT_FOUND,
+                        key_hints=['volume.metadata.name'],
+                        exc_info=exc,
+                    )
+                except AnnotationError:
+                    _log.exception(
+                        events.Annotation.ERROR,
+                        key_hints=['volume.metadata.name'],
+                    )
+                except UnsupportedVolume as exc:
+                    _log.info(
+                        events.Volume.UNSUPPORTED,
+                        key_hints=['volume.metadata.name'],
+                        exc_info=exc,
+                    )
+
                 _log = _log.bind(
                     rule=rule
                 )
-                if event.type == 'ADDED' or volume_name not in rules:
-                    _log.info(events.Rule.ADDED, key_hints=['rule.name'])
+
+                if rule:
+                    if event.type == 'ADDED' or volume_name not in rules:
+                        _log.info(
+                            events.Rule.ADDED,
+                            key_hints=['rule.name']
+                        )
+                    else:
+                        _log.info(
+                            events.Rule.UPDATED,
+                            key_hints=['rule.name']
+                        )
+                    rules[volume_name] = rule
                 else:
-                    _log.info(events.Rule.UPDATED, key_hints=['rule.name'])
-                rules[volume_name] = rule
-            else:
+                    if volume_name in rules:
+                        _log.info(
+                            events.Rule.REMOVED,
+                            key_hints=['volume_name']
+                        )
+                        rules.pop(volume_name)
+            elif event.type == 'DELETED':
                 if volume_name in rules:
-                    _log.info(events.Rule.REMOVED, key_hints=['volume_name'])
-                    rules.pop(volume_name, False)
-        elif event.type == 'DELETED':
-            _log.info(events.Rule.REMOVED, key_hints=['volume_name'])
-            rules.pop(volume_name, False)
-        else:
-            _log.warning('Unhandled event')
+                    _log.info(
+                        events.Rule.REMOVED,
+                        key_hints=['volume_name']
+                    )
+                    rules.pop(volume_name)
+            else:
+                _log.warning('Unhandled event')
 
-        yield list(rules.values())
+            yield list(rules.values())
 
-    _logger.debug('sync-get-rules.done')
+        _logger.debug('sync-get-rules.done')
 
 
 async def get_rules(ctx):
-    channel = Channel()
-    loop = asyncio.get_event_loop()
     _log = _logger.new()
 
-    _log.debug('get-rules.start')
-
-    def worker():
-        # sys.settrace(TracePrinter())
-        try:
-            _log.debug('Iterating in thread')
-            for value in sync_get_rules(ctx):
-                asyncio.ensure_future(channel.put(value), loop=loop)
-        except:
-            _log.exception('rules.error')
-        finally:
-            _log.warning('Closing channel')
-            channel.close()
-
-    thread = threading.Thread(
-        target=worker,
-        name='get_rules',
-        daemon=True
-    )
-
-    _log.debug('get-rules.thread.start')
-    thread.start()
-
-    async for item in channel:
+    async for item in rules_from_volumes(ctx):
         rules = ctx.config.get('rules') + item
         _log.debug('get-rules.rules.updated', rules=rules)
         yield rules
 
     _log.debug('get-rules.done')
-
-
-def snapshot_list_filter(ctx: Context) -> str:
-    key, value = snapshot_author_label(ctx)
-    return f'labels.{key} eq {value}'
-
-
-async def load_snapshots(ctx) -> List[Dict]:
-    resp = await run_in_executor(
-        ctx.gcloud().snapshots()
-        .list(
-            project=ctx.config['gcloud_project'],
-            filter=snapshot_list_filter(ctx),
-        )
-        .execute
-    )
-    return resp.get('items', [])
-
-
-async def get_snapshots(ctx, reload_trigger):
-    """Query the existing snapshots from Google Cloud.
-
-    If the channel "reload_trigger" contains any value, we
-    refresh the list of snapshots. This will then cause the
-    next backup to be scheduled.
-    """
-    yield await load_snapshots(ctx)
-    async for _ in reload_trigger:
-        yield await load_snapshots(ctx)
 
 
 async def watch_schedule(ctx, trigger, *, loop=None):
@@ -279,213 +249,6 @@ async def watch_schedule(ctx, trigger, *, loop=None):
         yield determine_next_snapshot(snapshots, rules)
 
 
-def new_snapshot_name(ctx: Context, rule: Rule) -> str:
-    """
-    Get a new snapshot name for rule.
-    Returns rule name and pendulum.now('utc') formatted according to settings.
-    """
-
-    time_str = re.sub(
-        r'[^-a-z0-9]', '-',
-        pendulum.now('utc').format(ctx.config['snapshot_datetime_format']),
-        flags=re.IGNORECASE)
-
-    # Won't be truncated
-    suffix = f'-{time_str}'
-
-    # Will be truncated
-    name_truncated = rule.name[:63 - len(suffix)]
-
-    return f'{name_truncated}{suffix}'
-
-
-def snapshot_labels(ctx: Context) -> Dict:
-    return dict([snapshot_author_label(ctx)])
-
-
-def snapshot_author_label(ctx: Context) -> Tuple[str, str]:
-    return (
-        ctx.config['snapshot_author_label_key'],
-        ctx.config['snapshot_author_label']
-    )
-
-
-async def make_backup(ctx, rule):
-    """Execute a single backup job.
-
-    1. Create the snapshot
-    2. Wait until the snapshot is finished.
-    3. Expire old snapshots
-    """
-    snapshot_name = new_snapshot_name(ctx, rule)
-
-    _log = _logger.new(
-        snapshot_name=snapshot_name,
-        rule=rule
-    )
-
-    gcloud = ctx.gcloud()
-
-    request_body = {
-        'name': snapshot_name,
-    }
-    _log.debug('createSnapshot.request-body', body=request_body)
-
-    try:
-        _log.info(
-            events.Snapshot.START,
-            key_hints=['snapshot_name', 'rule.name'],
-            request=request_body,
-        )
-
-        create_snapshot_op = await run_in_executor(
-            gcloud.disks().createSnapshot(
-                disk=rule.gce_disk,
-                project=ctx.config['gcloud_project'],
-                zone=rule.gce_disk_zone,
-                body=request_body
-            ).execute
-        )
-    except Exception as exc:
-        _log.exception(
-            events.Snapshot.ERROR,
-            key_hints=['snapshot_name', 'rule.name']
-        )
-        raise errors.SnapshotCreateError(
-            'Error creating snapshot'
-        ) from exc
-
-    _log = _log.bind(create_snapshot_operation=create_snapshot_op)
-
-    _log.debug('snapshot.started', key_hints=['create_snapshot_operation.status'])
-
-    # Immediately after creating the snapshot, it sometimes seems to
-    # take some seconds before it can be queried.
-    await asyncio.sleep(10)
-
-    snapshot = await get_snapshot(ctx, snapshot_name, gcloud=gcloud)
-
-    await set_snapshot_labels(
-        ctx,
-        snapshot,
-        snapshot_labels(ctx),
-        gcloud=gcloud
-    )
-
-    _log.debug('Waiting for snapshot to be ready')
-    while snapshot['status'] in ('PENDING', 'UPLOADING', 'CREATING'):
-        await asyncio.sleep(2)
-        _log.debug('snapshot.status.poll')
-        snapshot = await get_snapshot(ctx, snapshot_name, gcloud=gcloud)
-        _log.debug('snapshot.status.polled', snapshot=snapshot)
-
-    if not snapshot['status'] == 'READY':
-        _log.error(
-            events.Snapshot.ERROR,
-            snapshot=snapshot,
-            key_hints=['snapshot_name', 'rule.name'],
-        )
-        return
-
-    _log.info(
-        events.Snapshot.CREATED,
-        snapshot=snapshot,
-        key_hints=['snapshot_name', 'rule.name'],
-    )
-
-    ping_url = ctx.config.get('ping_url')
-    if ping_url:
-        with aiohttp.ClientSession() as session:
-            response = await session.request('GET', ping_url)
-            _log.info(
-                events.Ping.SENT,
-                status=response.status,
-                url=ping_url,
-            )
-
-    await expire_snapshots(ctx, rule)
-
-
-async def set_snapshot_labels(
-        ctx: Context,
-        snapshot: Dict,
-        labels: Dict,
-        gcloud: Optional[Resource]=None,
-):
-    _log = _logger.new(
-        snapshot=snapshot,
-        labels=labels,
-    )
-    gcloud = gcloud or ctx.gcloud()
-    body = {
-        'labels': labels,
-        'labelFingerprint': snapshot['labelFingerprint'],
-    }
-    _log.debug(
-        'snapshot.set-labels',
-        key_hints=['body.labels'],
-        body=body,
-    )
-    return await run_in_executor(
-        gcloud.snapshots().setLabels(
-            resource=snapshot['name'],
-            project=ctx.config['gcloud_project'],
-            body=body,
-        ).execute
-    )
-
-
-async def get_snapshot(
-        ctx: Context,
-        snapshot_name: str,
-        gcloud: Optional[Resource]=None,
-) -> Dict:
-    gcloud = gcloud or ctx.gcloud()
-    return await run_in_executor(
-        gcloud.snapshots().get(
-            snapshot=snapshot_name,
-            project=ctx.config['gcloud_project']
-        ).execute
-    )
-
-
-async def expire_snapshots(ctx, rule: Rule):
-    """
-    Expire existing snapshots for the rule.
-    """
-    _log = _logger.new(
-        rule=rule,
-    )
-    _log.debug('Expiring existing snapshots')
-
-    snapshots = await load_snapshots(ctx)
-    snapshots = filter_snapshots_by_rule(snapshots, rule)
-    snapshots = {s['name']: parse_creation_timestamp(s) for s in snapshots}
-
-    to_keep = expire(snapshots, rule.deltas)
-    for snapshot_name in snapshots:
-        _log = _log.new(
-            snapshot_name=snapshot_name,
-        )
-        if snapshot_name in to_keep:
-            _log.debug('expire.keep')
-            continue
-
-        if snapshot_name not in to_keep:
-            _log.debug('snapshot.expiring')
-            result = await run_in_executor(
-                ctx.gcloud().snapshots().delete(
-                    snapshot=snapshot_name,
-                    project=ctx.config['gcloud_project']
-                ).execute
-            )
-            _log.info(
-                events.Snapshot.EXPIRED,
-                key_hint='snapshot_name',
-                result=result
-            )
-
-
 async def scheduler(ctx, scheduling_chan, snapshot_reload_trigger):
     """The "when to make a backup schedule" depends on the backup delta
     rules as defined in Kubernetes volume resources, and the existing
@@ -523,6 +286,10 @@ async def backuper(ctx, scheduling_chan, snapshot_reload_trigger):
             else:
                 _log.debug(
                     'backuper.next-backup',
+                    key_hints=[
+                        'rule.name',
+                        'target_time',
+                    ],
                     rule=current_target_rule,
                     target_time=current_target_time,
                     diff=current_target_time.diff(),

--- a/k8s_snapshots/core.py
+++ b/k8s_snapshots/core.py
@@ -130,7 +130,7 @@ def sync_get_rules(ctx):
                 )
 
             if rule:
-                _log.bind(
+                _log = _log.bind(
                     rule=rule
                 )
                 if event.type == 'ADDED' or volume_name not in rules:

--- a/k8s_snapshots/core.py
+++ b/k8s_snapshots/core.py
@@ -7,12 +7,13 @@ import aiohttp
 import re
 import threading
 from datetime import timedelta
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Optional
 
 import pendulum
 import pykube
 import structlog
 from aiochannel import Channel, ChannelEmpty
+from googleapiclient.discovery import Resource
 from tarsnapper.expire import expire
 
 from k8s_snapshots import errors, events
@@ -38,6 +39,12 @@ def filter_snapshots_by_rule(snapshots, rule) -> Iterable:
     return filter(match_disk, snapshots)
 
 
+def parse_creation_timestamp(snapshot: Dict) -> pendulum.Pendulum:
+    return pendulum.parse(
+        snapshot['creationTimestamp']
+    ).in_timezone('utc')
+
+
 def determine_next_snapshot(snapshots, rules):
     """
     Given a list of snapshots, and a list of rules, determine the next snapshot
@@ -51,25 +58,25 @@ def determine_next_snapshot(snapshots, rules):
     for rule in rules:
         _log = _logger.new(rule=rule)
         # Find all the snapshots that match this rule
-        filtered = filter_snapshots_by_rule(snapshots, rule)
+        snapshots_for_rule = filter_snapshots_by_rule(snapshots, rule)
         # Rewrite the list to snapshot
-        filtered = map(lambda s: pendulum.parse(s['creationTimestamp']), filtered)
+        snapshot_times = map(parse_creation_timestamp, snapshots_for_rule)
         # Sort by timestamp
-        filtered = sorted(filtered, reverse=True)
-        filtered = list(filtered)
+        snapshot_times = sorted(snapshot_times, reverse=True)
+        snapshot_times = list(snapshot_times)
 
         # There are no snapshots for this rule; create the first one.
-        if not filtered:
+        if not snapshot_times:
             next_rule = rule
             next_timestamp = pendulum.now('utc') + timedelta(seconds=10)
             _log.info(
                 events.Snapshot.SCHEDULED,
                 target=next_timestamp,
-                key_hints=['rule'],
+                key_hints=['rule.name', 'target'],
             )
             break
 
-        target = filtered[0] + rule.deltas[0]
+        target = snapshot_times[0] + rule.deltas[0]
         if not next_timestamp or target < next_timestamp:
             next_rule = rule
             next_timestamp = target
@@ -77,6 +84,7 @@ def determine_next_snapshot(snapshots, rules):
     if next_rule is not None and next_timestamp is not None:
         _logger.info(
             events.Snapshot.SCHEDULED,
+            key_hints=['rule.name', 'target'],
             target=next_timestamp,
             rule=next_rule,
         )
@@ -112,26 +120,30 @@ def sync_get_rules(ctx):
             except AnnotationNotFound as exc:
                 _log.info(
                     events.Annotation.NOT_FOUND,
+                    key_hints=['volume.name'],
                     exc_info=exc,
                 )
             except AnnotationError:
-                _log.exception(events.Annotation.ERROR)
+                _log.exception(
+                    events.Annotation.ERROR,
+                    key_hints=['volume.name']
+                )
 
             if rule:
                 _log.bind(
                     rule=rule
                 )
                 if event.type == 'ADDED' or volume_name not in rules:
-                    _log.info(events.Rule.ADDED)
+                    _log.info(events.Rule.ADDED, key_hints=['rule.name'])
                 else:
-                    _log.info(events.Rule.UPDATED)
+                    _log.info(events.Rule.UPDATED, key_hints=['rule.name'])
                 rules[volume_name] = rule
             else:
                 if volume_name in rules:
-                    _log.info(events.Rule.REMOVED)
+                    _log.info(events.Rule.REMOVED, key_hints=['volume_name'])
                     rules.pop(volume_name, False)
         elif event.type == 'DELETED':
-            _log.info(events.Rule.REMOVED)
+            _log.info(events.Rule.REMOVED, key_hints=['volume_name'])
             rules.pop(volume_name, False)
         else:
             _log.warning('Unhandled event')
@@ -179,7 +191,7 @@ async def get_rules(ctx):
 
 async def load_snapshots(ctx) -> Dict:
     resp = await run_in_executor(
-        ctx.make_gclient().snapshots()
+        ctx.gcloud().snapshots()
         .list(project=ctx.config['gcloud_project'])
         .execute
     )
@@ -198,7 +210,7 @@ async def get_snapshots(ctx, reload_trigger):
         yield await load_snapshots(ctx)
 
 
-async def watch_schedule(ctx, trigger):
+async def watch_schedule(ctx, trigger, *, loop=None):
     """Continually yields the next backup to be created.
 
     It watches two input sources: the rules as defined by
@@ -206,6 +218,7 @@ async def watch_schedule(ctx, trigger):
     from Google Cloud. If either of them change, a new backup
     is scheduled.
     """
+    loop = loop or asyncio.get_event_loop()
     _log = _logger.new()
 
     rulesgen = get_rules(ctx)
@@ -218,6 +231,27 @@ async def watch_schedule(ctx, trigger):
         snapshots=snapgen,
         defaults={'snapshots': None, 'rules': None}
     )
+
+    rules = None
+
+    heartbeat_interval_seconds = ctx.config.get(
+        'schedule_heartbeat_interval_seconds'
+    )
+
+    async def heartbeat():
+        _logger.info(
+            events.Rule.HEARTBEAT,
+            rules=rules,
+        )
+
+        loop.call_later(
+            heartbeat_interval_seconds,
+            asyncio.ensure_future,
+            heartbeat()
+        )
+
+    if heartbeat_interval_seconds:
+        asyncio.ensure_future(heartbeat())
 
     async for item in combined:
         rules = item.get('rules')
@@ -237,6 +271,33 @@ async def watch_schedule(ctx, trigger):
         yield determine_next_snapshot(snapshots, rules)
 
 
+def new_snapshot_name(ctx: Context, rule: Rule) -> str:
+    """
+    Get a new snapshot name for rule.
+    Returns rule name and pendulum.now('utc') formatted according to settings.
+    """
+
+    time_str = re.sub(
+        r'[^-a-z0-9]', '-',
+        pendulum.now('utc').format(ctx.config['snapshot_datetime_format']),
+        flags=re.IGNORECASE)
+
+    # Won't be truncated
+    suffix = f'-{time_str}'
+
+    # Will be truncated
+    name_truncated = rule.name[:63 - len(suffix)]
+
+    return f'{name_truncated}{suffix}'
+
+
+def make_snapshot_labels(ctx: Context, rule: Rule) -> Dict:
+    return {
+        ctx.config['snapshot_author_label_key']:
+            ctx.config['snapshot_author_label']
+    }
+
+
 async def make_backup(ctx, rule):
     """Execute a single backup job.
 
@@ -244,33 +305,28 @@ async def make_backup(ctx, rule):
     2. Wait until the snapshot is finished.
     3. Expire old snapshots
     """
-    snapshot_time_str = re.sub(
-        r'[^a-z0-9-]', '-',
-        pendulum.now('utc').format(ctx.config['snapshot_datetime_format']),
-        flags=re.IGNORECASE)
-    snapshot_name = f'{rule.pretty_name}-{snapshot_time_str}'
+    snapshot_name = new_snapshot_name(ctx, rule)
 
     _log = _logger.new(
         snapshot_name=snapshot_name,
         rule=rule
     )
 
-    gcloud = ctx.make_gclient()
-    labels = {
-        ctx.config['snapshot_author_label_key']:
-            ctx.config['snapshot_author_label']
-    }
+    gcloud = ctx.gcloud()
 
     request_body = {
         'name': snapshot_name,
-        'labels': labels,
     }
     _log.debug('createSnapshot.request-body', body=request_body)
 
     try:
-        _log.info(events.Snapshot.START, key_hints=['rule.name', 'snapshot_name'])
+        _log.info(
+            events.Snapshot.START,
+            key_hints=['snapshot_name', 'rule.name'],
+            request=request_body,
+        )
 
-        result = await run_in_executor(
+        create_snapshot_op = await run_in_executor(
             gcloud.disks().createSnapshot(
                 disk=rule.gce_disk,
                 project=ctx.config['gcloud_project'],
@@ -279,36 +335,49 @@ async def make_backup(ctx, rule):
             ).execute
         )
     except Exception as exc:
-        _log.exception(events.Snapshot.ERROR)
-        raise errors.SnapshotCreateError('Call to API raised an error') from exc
+        _log.exception(
+            events.Snapshot.ERROR,
+            key_hints=['snapshot_name', 'rule.name']
+        )
+        raise errors.SnapshotCreateError(
+            'Error creating snapshot'
+        ) from exc
 
-    _log = _log.bind(create_snapshot=result)
+    _log = _log.bind(create_snapshot_operation=create_snapshot_op)
 
-    _log.debug('snapshot.started', key_hints=['create_snapshot.status'])
+    _log.debug('snapshot.started', key_hints=['create_snapshot_operation.status'])
 
     # Immediately after creating the snapshot, it sometimes seems to
     # take some seconds before it can be queried.
     await asyncio.sleep(10)
 
+    snapshot = await get_snapshot(ctx, snapshot_name, gcloud=gcloud)
+
+    await set_snapshot_labels(
+        ctx,
+        snapshot,
+        make_snapshot_labels(ctx, rule),
+        gcloud=gcloud
+    )
+
     _log.debug('Waiting for snapshot to be ready')
-    while result['status'] in ('PENDING', 'UPLOADING', 'CREATING'):
+    while snapshot['status'] in ('PENDING', 'UPLOADING', 'CREATING'):
         await asyncio.sleep(2)
         _log.debug('snapshot.status.poll')
-        result = await run_in_executor(
-            gcloud.snapshots().get(
-                snapshot=snapshot_name,
-                project=ctx.config['gcloud_project']
-            ).execute
-        )
-        _log.debug('snapshot.status.polled', result=result)
+        snapshot = await get_snapshot(ctx, snapshot_name, gcloud=gcloud)
+        _log.debug('snapshot.status.polled', snapshot=snapshot)
 
-    if not result['status'] == 'READY':
-        _log.error(events.Snapshot.ERROR, result=result)
+    if not snapshot['status'] == 'READY':
+        _log.error(
+            events.Snapshot.ERROR,
+            snapshot=snapshot,
+            key_hints=['snapshot_name', 'rule.name'],
+        )
         return
 
     _log.info(
         events.Snapshot.CREATED,
-        last_result=result,
+        snapshot=snapshot,
         key_hints=['snapshot_name', 'rule.name'],
     )
 
@@ -323,6 +392,49 @@ async def make_backup(ctx, rule):
             )
 
     await expire_snapshots(ctx, rule)
+
+
+async def set_snapshot_labels(
+        ctx: Context,
+        snapshot: Dict,
+        labels: Dict,
+        gcloud: Optional[Resource]=None,
+):
+    _log = _logger.new(
+        snapshot=snapshot,
+        labels=labels,
+    )
+    gcloud = gcloud or ctx.gcloud()
+    body = {
+        'labels': labels,
+        'labelFingerprint': snapshot['labelFingerprint'],
+    }
+    _log.debug(
+        'snapshot.set-labels',
+        key_hints=['body.labels'],
+        body=body,
+    )
+    return await run_in_executor(
+        gcloud.snapshots().setLabels(
+            resource=snapshot['name'],
+            project=ctx.config['gcloud_project'],
+            body=body,
+        ).execute
+    )
+
+
+async def get_snapshot(
+        ctx: Context,
+        snapshot_name: str,
+        gcloud: Optional[Resource]=None,
+) -> Dict:
+    gcloud = gcloud or ctx.gcloud()
+    return await run_in_executor(
+        gcloud.snapshots().get(
+            snapshot=snapshot_name,
+            project=ctx.config['gcloud_project']
+        ).execute
+    )
 
 
 async def expire_snapshots(ctx, rule: Rule):
@@ -350,7 +462,7 @@ async def expire_snapshots(ctx, rule: Rule):
         if snapshot_name not in to_keep:
             _log.debug('snapshot.expiring')
             result = await run_in_executor(
-                ctx.make_gclient().snapshots().delete(
+                ctx.gcloud().snapshots().delete(
                     snapshot=snapshot_name,
                     project=ctx.config['gcloud_project']
                 ).execute

--- a/k8s_snapshots/core.py
+++ b/k8s_snapshots/core.py
@@ -120,13 +120,13 @@ def sync_get_rules(ctx):
             except AnnotationNotFound as exc:
                 _log.info(
                     events.Annotation.NOT_FOUND,
-                    key_hints=['volume.name'],
+                    key_hints=['volume.metadata.name'],
                     exc_info=exc,
                 )
             except AnnotationError:
                 _log.exception(
                     events.Annotation.ERROR,
-                    key_hints=['volume.name']
+                    key_hints=['volume.metadata.name']
                 )
 
             if rule:

--- a/k8s_snapshots/errors.py
+++ b/k8s_snapshots/errors.py
@@ -1,5 +1,5 @@
 import traceback
-from typing import Dict
+from typing import Dict, List, Iterable
 
 
 class StructuredError(Exception):
@@ -13,6 +13,39 @@ class StructuredError(Exception):
     def __repr__(self):
         return f'<{self.__class__.__name__}: {self.message} ' \
                f'data={self.data!r}>'
+
+    def __structlog__(self):
+        return self._serializable_exc()
+
+    def _exc_chain(self) -> Iterable[Exception]:
+        chain = []  # reverse chronological order
+        exc = self
+
+        while exc is not None:
+            chain.append(exc)
+            exc = exc.__cause__
+
+        return reversed(chain)
+
+    def _serializable_exc(self) -> List[Dict]:
+        def serialize_exc(exc: Exception) -> Dict:
+            if isinstance(exc, StructuredError):
+                return exc.to_dict()
+            else:
+                exc_type = exc.__class__
+                exc_tb = exc.__traceback__
+                return {
+                    'type': exc_type.__qualname__,
+                    'message': str(exc),
+                    'readable': traceback.format_exception(
+                        exc_type,
+                        exc,
+                        exc_tb,
+                        chain=False
+                    )
+                }
+
+        return [serialize_exc(exc) for exc in self._exc_chain()]
 
     def to_dict(self) -> Dict:
         return {
@@ -29,13 +62,26 @@ class StructuredError(Exception):
 
 
 class ConfigurationError(StructuredError):
+    """ Raised for invalid configuration """
+    pass
+
+
+class DeltasParseError(StructuredError):
+    """
+    Raised for invalid delta strings
+
+    -   In configuration.
+    -   In PV or PVC annotations.
+    """
+    pass
+
+
+class VolumeNotFound(StructuredError):
     pass
 
 
 class UnsupportedVolume(StructuredError):
-    """
-    Raised for PersistentVolumes we can't snapshot.
-    """
+    """ Raised for PersistentVolumes we can't snapshot """
     pass
 
 

--- a/k8s_snapshots/errors.py
+++ b/k8s_snapshots/errors.py
@@ -2,7 +2,6 @@ import traceback
 from typing import Dict
 
 
-
 class StructuredError(Exception):
     def __init__(self, message=None, **data):
         self.message = message

--- a/k8s_snapshots/events.py
+++ b/k8s_snapshots/events.py
@@ -24,6 +24,24 @@ class Annotation(EventEnum):
 
 
 @enum.unique
+class VolumeEvent(EventEnum):
+    """
+    Events related to Kubernetes PersistentVolume and PersistentVolumeClaim
+    resource events.
+    """
+    RECEIVED = 'volume-event.received'
+
+
+@enum.unique
+class Volume(EventEnum):
+    """
+    Events related to Kubernetes PersistentVolumes
+    """
+    UNSUPPORTED = 'volume.unsupported'
+    NOT_FOUND = 'volume.not-found'
+
+
+@enum.unique
 class Snapshot(EventEnum):
     """
     Events related to snapshots.

--- a/k8s_snapshots/events.py
+++ b/k8s_snapshots/events.py
@@ -44,6 +44,7 @@ class Rule(EventEnum):
     ADDED = 'rule.added'
     UPDATED = 'rule.updated'
     REMOVED = 'rule.removed'
+    HEARTBEAT = 'rule.heartbeat'
 
 
 @enum.unique

--- a/k8s_snapshots/kube.py
+++ b/k8s_snapshots/kube.py
@@ -1,0 +1,102 @@
+import asyncio
+import threading
+from typing import Optional, Iterable, NamedTuple, AsyncGenerator, Any, TypeVar
+
+import pykube
+import structlog
+from aiochannel import Channel
+
+from k8s_snapshots.context import Context
+
+_logger = structlog.get_logger(__name__)
+
+KubeResourceType = TypeVar(
+    'KubeResourceType',
+)
+
+
+def get_resource_or_none_sync(
+        client: pykube.HTTPClient,
+        resource_type: type(KubeResourceType),
+        name: str,
+        namespace: Optional[str]=None,
+) -> Optional[KubeResourceType]:
+    resource_query = resource_type.objects(client)
+    if namespace is not None:
+        resource_query = resource_query.filter(
+            namespace=namespace
+        )
+
+    return resource_query.get_or_none(name=name)
+
+
+async def get_resource_or_none(
+        ctx: Context,
+        resource_type: type(pykube.objects.APIObject),
+        name: str,
+        namespace: Optional[str]=None,
+        *,
+        loop=None
+) -> Optional[pykube.objects.APIObject]:
+    loop = loop or asyncio.get_event_loop()
+
+    def _get():
+        return get_resource_or_none_sync(
+            client=ctx.kube_client(),
+            resource_type=resource_type,
+            name=name,
+            namespace=namespace,
+        )
+
+    return await loop.run_in_executor(
+        None,
+        _get,
+    )
+
+
+def watch_resources_sync(
+        client: pykube.HTTPClient,
+        resource_type: type(pykube.objects.APIObject),
+) -> Iterable:
+    return resource_type.objects(client).watch().object_stream()
+
+
+async def watch_resources(
+        ctx: Context,
+        resource_type: type(KubeResourceType),
+        *,
+        loop=None
+) -> AsyncGenerator[KubeResourceType, None]:
+    loop = loop or asyncio.get_event_loop()
+    _log = _logger.bind(
+        resource_type_name=resource_type.__name__,
+    )
+    channel = Channel()
+
+    def worker():
+        try:
+            _log.debug('watch-resources.worker.start')
+            sync_iterator = watch_resources_sync(
+                ctx.kube_client(),
+                resource_type
+            )
+            for event in sync_iterator:
+                # only put_nowait seems to cause SIGSEGV
+                loop.call_soon_threadsafe(channel.put_nowait, event)
+        except:
+            _log.exception('watch-resources.worker.error')
+        finally:
+            _log.debug('watch-resources.worker.finalized')
+            channel.close()
+
+    thread = threading.Thread(
+        target=worker,
+        daemon=True,
+    )
+    thread.start()
+
+    async for event in channel:
+        yield event
+
+    _log.debug('watch-resources.done')
+

--- a/k8s_snapshots/logconf.py
+++ b/k8s_snapshots/logconf.py
@@ -1,11 +1,9 @@
-import traceback
 from collections import OrderedDict
-from typing import Optional, List, Any, Dict, Iterable
+from typing import Optional, List, Any, Dict
 
 import logbook
 import structlog
 
-from k8s_snapshots.errors import StructuredError
 from k8s_snapshots.serialize import SnapshotsJSONEncoder
 
 
@@ -226,7 +224,7 @@ def configure_structlog(
             ],
             context_class=OrderedDict,
             logger_factory=logger_factory,
-            wrapper_class=structlog.stdlib.BoundLogger,
+            wrapper_class=structlog.BoundLogger,
             cache_logger_on_first_use=True,
         )
     else:
@@ -250,7 +248,7 @@ def configure_structlog(
                 )
             ],
             context_class=OrderedDict,
-            wrapper_class=structlog.stdlib.BoundLogger,
+            wrapper_class=structlog.BoundLogger,
             logger_factory=logger_factory,
             cache_logger_on_first_use=True,
         )

--- a/k8s_snapshots/logging.py
+++ b/k8s_snapshots/logging.py
@@ -1,0 +1,12 @@
+import attr
+
+
+class Loggable:
+    def __structlog__(self):
+        if attr.has(self.__class__):
+            return attr.asdict(self)
+
+        if hasattr(self, 'to_dict') and callable(self.to_dict):
+            return self.to_dict()
+
+        return self

--- a/k8s_snapshots/snapshot.py
+++ b/k8s_snapshots/snapshot.py
@@ -1,0 +1,328 @@
+import asyncio
+from datetime import timedelta
+from typing import Optional, Dict, Tuple, List, Iterable
+
+import aiohttp
+import pendulum
+import re
+import structlog
+from googleapiclient.discovery import Resource
+from tarsnapper.expire import expire
+
+from k8s_snapshots import events, errors
+from k8s_snapshots.asyncutils import run_in_executor
+from k8s_snapshots.context import Context
+from k8s_snapshots.rule import Rule
+
+_logger = structlog.get_logger(__name__)
+
+
+async def get_snapshot(
+        ctx: Context,
+        snapshot_name: str,
+        gcloud: Optional[Resource]=None,
+) -> Dict:
+    gcloud = gcloud or ctx.gcloud()
+    return await run_in_executor(
+        gcloud.snapshots().get(
+            snapshot=snapshot_name,
+            project=ctx.config['gcloud_project']
+        ).execute
+    )
+
+
+async def expire_snapshots(ctx, rule: Rule):
+    """
+    Expire existing snapshots for the rule.
+    """
+    _log = _logger.new(
+        rule=rule,
+    )
+    _log.debug('snapshot.expired')
+
+    snapshots = await load_snapshots(ctx)
+    snapshots = filter_snapshots_by_rule(snapshots, rule)
+    snapshots = {s['name']: parse_creation_timestamp(s) for s in snapshots}
+
+    to_keep = expire(snapshots, rule.deltas)
+    expired_snapshots = []
+    kept_snapshots = []
+
+    for snapshot_name, snapshot_time_created in snapshots.items():
+        _log = _log.new(
+            snapshot_name=snapshot_name,
+            snapshot_time_created=snapshot_time_created,
+            key_hints=[
+                'snapshot_name',
+                'snapshot_time_created',
+            ]
+        )
+        if snapshot_name in to_keep:
+            _log.debug('expire.keep')
+            kept_snapshots.append(snapshot_name)
+            continue
+
+        if snapshot_name not in to_keep:
+            _log.debug('snapshot.expiring')
+            result = await run_in_executor(
+                ctx.gcloud().snapshots().delete(
+                    snapshot=snapshot_name,
+                    project=ctx.config['gcloud_project']
+                ).execute
+            )
+            expired_snapshots.append(snapshot_name)
+
+    _log.info(
+        events.Snapshot.EXPIRED,
+        key_hint='snapshot_name',
+        snapshots={
+            'expired': expired_snapshots,
+            'kept': kept_snapshots,
+        }
+    )
+
+
+async def make_backup(ctx, rule):
+    """Execute a single backup job.
+
+    1. Create the snapshot
+    2. Wait until the snapshot is finished.
+    3. Expire old snapshots
+    """
+    snapshot_name = new_snapshot_name(ctx, rule)
+
+    _log = _logger.new(
+        snapshot_name=snapshot_name,
+        rule=rule
+    )
+
+    gcloud = ctx.gcloud()
+
+    request_body = {
+        'name': snapshot_name,
+    }
+    _log.debug('createSnapshot.request-body', body=request_body)
+
+    try:
+        _log.info(
+            events.Snapshot.START,
+            key_hints=['snapshot_name', 'rule.name'],
+            request=request_body,
+        )
+
+        create_snapshot_op = await run_in_executor(
+            gcloud.disks().createSnapshot(
+                disk=rule.gce_disk,
+                project=ctx.config['gcloud_project'],
+                zone=rule.gce_disk_zone,
+                body=request_body
+            ).execute
+        )
+    except Exception as exc:
+        _log.exception(
+            events.Snapshot.ERROR,
+            key_hints=['snapshot_name', 'rule.name']
+        )
+        raise errors.SnapshotCreateError(
+            'Error creating snapshot'
+        ) from exc
+
+    _log = _log.bind(create_snapshot_operation=create_snapshot_op)
+
+    _log.debug('snapshot.started', key_hints=['create_snapshot_operation.status'])
+
+    # Immediately after creating the snapshot, it sometimes seems to
+    # take some seconds before it can be queried.
+    await asyncio.sleep(10)
+
+    snapshot = await get_snapshot(ctx, snapshot_name, gcloud=gcloud)
+
+    await set_snapshot_labels(
+        ctx,
+        snapshot,
+        snapshot_labels(ctx),
+        gcloud=gcloud
+    )
+
+    _log.debug('Waiting for snapshot to be ready')
+    while snapshot['status'] in ('PENDING', 'UPLOADING', 'CREATING'):
+        await asyncio.sleep(2)
+        _log.debug('snapshot.status.poll')
+        snapshot = await get_snapshot(ctx, snapshot_name, gcloud=gcloud)
+        _log.debug('snapshot.status.polled', snapshot=snapshot)
+
+    if not snapshot['status'] == 'READY':
+        _log.error(
+            events.Snapshot.ERROR,
+            snapshot=snapshot,
+            key_hints=['snapshot_name', 'rule.name'],
+        )
+        return
+
+    _log.info(
+        events.Snapshot.CREATED,
+        snapshot=snapshot,
+        key_hints=['snapshot_name', 'rule.name'],
+    )
+
+    ping_url = ctx.config.get('ping_url')
+    if ping_url:
+        with aiohttp.ClientSession() as session:
+            response = await session.request('GET', ping_url)
+            _log.info(
+                events.Ping.SENT,
+                status=response.status,
+                url=ping_url,
+            )
+
+    await expire_snapshots(ctx, rule)
+
+
+def snapshot_author_label(ctx: Context) -> Tuple[str, str]:
+    return (
+        ctx.config['snapshot_author_label_key'],
+        ctx.config['snapshot_author_label']
+    )
+
+
+def snapshot_labels(ctx: Context) -> Dict:
+    return dict([snapshot_author_label(ctx)])
+
+
+async def set_snapshot_labels(
+        ctx: Context,
+        snapshot: Dict,
+        labels: Dict,
+        gcloud: Optional[Resource]=None,
+):
+    _log = _logger.new(
+        snapshot=snapshot,
+        labels=labels,
+    )
+    gcloud = gcloud or ctx.gcloud()
+    body = {
+        'labels': labels,
+        'labelFingerprint': snapshot['labelFingerprint'],
+    }
+    _log.debug(
+        'snapshot.set-labels',
+        key_hints=['body.labels'],
+        body=body,
+    )
+    return await run_in_executor(
+        gcloud.snapshots().setLabels(
+            resource=snapshot['name'],
+            project=ctx.config['gcloud_project'],
+            body=body,
+        ).execute
+    )
+
+
+def new_snapshot_name(ctx: Context, rule: Rule) -> str:
+    """
+    Get a new snapshot name for rule.
+    Returns rule name and pendulum.now('utc') formatted according to settings.
+    """
+
+    time_str = re.sub(
+        r'[^-a-z0-9]', '-',
+        pendulum.now('utc').format(ctx.config['snapshot_datetime_format']),
+        flags=re.IGNORECASE)
+
+    # Won't be truncated
+    suffix = f'-{time_str}'
+
+    # Will be truncated
+    name_truncated = rule.name[:63 - len(suffix)]
+
+    return f'{name_truncated}{suffix}'
+
+
+async def get_snapshots(ctx, reload_trigger):
+    """Query the existing snapshots from Google Cloud.
+
+    If the channel "reload_trigger" contains any value, we
+    refresh the list of snapshots. This will then cause the
+    next backup to be scheduled.
+    """
+    yield await load_snapshots(ctx)
+    async for _ in reload_trigger:
+        yield await load_snapshots(ctx)
+
+
+async def load_snapshots(ctx) -> List[Dict]:
+    resp = await run_in_executor(
+        ctx.gcloud().snapshots()
+        .list(
+            project=ctx.config['gcloud_project'],
+            filter=snapshot_list_filter(ctx),
+        )
+        .execute
+    )
+    return resp.get('items', [])
+
+
+def snapshot_list_filter(ctx: Context) -> str:
+    key, value = snapshot_author_label(ctx)
+    return f'labels.{key} eq {value}'
+
+
+def parse_creation_timestamp(snapshot: Dict) -> pendulum.Pendulum:
+    return pendulum.parse(
+        snapshot['creationTimestamp']
+    ).in_timezone('utc')
+
+
+def determine_next_snapshot(snapshots, rules):
+    """
+    Given a list of snapshots, and a list of rules, determine the next snapshot
+    to be made.
+
+    Returns a 2-tuple (rule, target_datetime)
+    """
+    next_rule = None
+    next_timestamp = None
+
+    for rule in rules:
+        _log = _logger.new(rule=rule)
+        # Find all the snapshots that match this rule
+        snapshots_for_rule = filter_snapshots_by_rule(snapshots, rule)
+        # Rewrite the list to snapshot
+        snapshot_times = map(parse_creation_timestamp, snapshots_for_rule)
+        # Sort by timestamp
+        snapshot_times = sorted(snapshot_times, reverse=True)
+        snapshot_times = list(snapshot_times)
+
+        # There are no snapshots for this rule; create the first one.
+        if not snapshot_times:
+            next_rule = rule
+            next_timestamp = pendulum.now('utc') + timedelta(seconds=10)
+            _log.info(
+                events.Snapshot.SCHEDULED,
+                target=next_timestamp,
+                key_hints=['rule.name', 'target'],
+            )
+            break
+
+        target = snapshot_times[0] + rule.deltas[0]
+        if not next_timestamp or target < next_timestamp:
+            next_rule = rule
+            next_timestamp = target
+
+    if next_rule is not None and next_timestamp is not None:
+        _logger.info(
+            events.Snapshot.SCHEDULED,
+            key_hints=['rule.name', 'target'],
+            target=next_timestamp,
+            rule=next_rule,
+        )
+
+    return next_rule, next_timestamp
+
+
+def filter_snapshots_by_rule(snapshots, rule) -> Iterable:
+    def match_disk(snapshot):
+        url_part = '/zones/{zone}/disks/{name}'.format(
+            zone=rule.gce_disk_zone, name=rule.gce_disk)
+        return snapshot['sourceDisk'].endswith(url_part)
+    return filter(match_disk, snapshots)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ confcollect==0.2.3
 isodate==0.5.4
 python-dateutil==2.6.0
 aiohttp==2.2.2
+aiostream==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ attrs==17.2.0
 pendulum==0.8.0
 confcollect==0.2.3
 isodate==0.5.4
+python-dateutil==2.6.0
 aiohttp==2.2.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from k8s_snapshots.logconf import configure_logging
+
+
+@pytest.fixture(scope='session', autouse=True)
+def configured_logging():
+    configure_logging(
+        level_name='DEBUG',
+        for_humans=True,
+    )
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,5 @@ def configured_logging():
         for_humans=True,
     )
 
+from .fixtures import *  # noqa
+from .fixtures.kube import *  # noqa

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,22 @@
+from unittest import mock
+
+import pytest
+
+from k8s_snapshots import errors
+from k8s_snapshots.context import Context
+from tests.fixtures.kube import make_resource, KUBE_CONFIG
+
+
+@pytest.fixture
+def fx_context(request):
+    request.getfixturevalue('fx_mock_context_kube_config')
+    request.getfixturevalue('fx_mock_context_kube_client')
+    ctx = Context({
+        'deltas_annotation_key': 'test.k8s-snapshots.example/deltas'
+    })
+    return ctx
+
+
+@pytest.fixture
+def fx_deltas(request):
+    return 'PT10S PT40S'

--- a/tests/fixtures/kube.py
+++ b/tests/fixtures/kube.py
@@ -1,0 +1,314 @@
+import contextlib
+from typing import Dict, Iterable, Optional, Tuple, List, Any, Type, Hashable, \
+    NamedTuple, Generator, Callable
+from unittest import mock
+from unittest.mock import MagicMock, Mock
+
+import structlog
+import pykube
+import pytest
+from _pytest.fixtures import FixtureRequest
+
+from k8s_snapshots import kube, errors
+from k8s_snapshots.context import Context
+
+_logger = structlog.get_logger(__name__)
+
+KUBE_SAFETY_CHECK_CONFIG_KEY = 'test-fixture-safety-check'
+
+KUBE_CONFIG = pykube.KubeConfig({
+    'apiVersion': 'v1',
+    'kind': 'Config',
+    'clusters': [
+        {
+            'name': 'test-fixture-cluster',
+            'certificate-authority-data': 'From fixture fx_kube_config',
+            'server': 'http://test-fixture-server',
+        },
+    ],
+    'contexts': [
+        {
+            'name': 'test-fixture-context',
+            'context': {
+                'cluster': 'test-fixture-cluster',
+                'user': 'test-fixture-user',
+            },
+        },
+    ],
+    'current-context': 'test-fixture-context',
+    KUBE_SAFETY_CHECK_CONFIG_KEY: 'I am present',
+})
+
+ANNOTATION_PROVISIONED_BY_VALUE = 'kubernetes.io/gce-pd'
+
+ANNOTATION_PROVISIONED_BY_KEY = 'pv.kubernetes.io/provisioned-by'
+
+ANNOTATION_PROVISIONED_BY = {
+    ANNOTATION_PROVISIONED_BY_KEY: ANNOTATION_PROVISIONED_BY_VALUE
+}
+
+LABEL_ZONE_VALUE = 'test-zone'
+
+LABEL_ZONE_KEY = 'failure-domain.beta.kubernetes.io/zone'
+LABEL_ZONE = {LABEL_ZONE_KEY: LABEL_ZONE_VALUE}
+
+DELTAS_ANNOTATION = 'PT1M PT2M'
+
+DEFAULT = object()
+
+
+@pytest.fixture(scope='session', autouse=True)
+def fx_mock_context_kube_config():
+    with mock.patch(
+            'k8s_snapshots.context.Context.load_kube_config',
+            return_value=KUBE_CONFIG) as _mock:
+        assert Context().load_kube_config() == KUBE_CONFIG
+        yield _mock
+
+
+@pytest.fixture(scope='session', autouse=True)
+def fx_mock_context_kube_client():
+    def _fake_client(self: Context):
+        return MagicMock(
+            spec=pykube.HTTPClient,
+            config=self.load_kube_config()
+        )
+    with mock.patch(
+        'k8s_snapshots.context.Context.kube_client',
+        _fake_client,
+    ) as _mock:
+        yield _mock
+
+
+@pytest.fixture
+def fx_kube_config(request: FixtureRequest) -> pykube.KubeConfig:
+    """
+    Minimal fake pykube.HTTPClient config fixture.
+    """
+    return KUBE_CONFIG
+
+
+class MockKubernetes(kube.Kubernetes):
+    def __init__(self, *args, **kwargs):
+        super(MockKubernetes, self).__init__(*args, **kwargs)
+
+    def get_or_none(
+            self,
+            resource_type: Type[kube.Resource],
+            name: str,
+            namespace: Optional[str]=None,
+    ) -> Optional[kube.Resource]:
+        return self.resource_map.get(
+            self.make_key(
+                resource_type,
+                name,
+                namespace
+            )
+        )
+
+    def watch(
+            self,
+            resource_type: Type[kube.Resource],
+    ):
+        raise NotImplementedError
+
+    # Mock-specific methods
+
+    ResourceKey = NamedTuple(
+        'ResourceKey',
+        [
+            ('namespace', str),
+            ('resource_type', Type[kube.Resource]),
+            ('name', str)
+        ]
+    )
+
+    resource_map: Dict[ResourceKey, kube.Resource] = {}
+
+    # def filter_resources(
+    #         self,
+    #         namespace: Optional[str]=None,
+    #         resource_type: Optional[Type[kube.Resource]]=None,
+    #         name: Optional[str]=None
+    # ) -> Generator[kube.Resource, None, None]:
+    #     tests: List[Callable[[self.ResourceKey, kube.Resource], bool]]
+    #     tests = []
+    #     if namespace is not None:
+    #         tests.append(lambda k, v: k.namespace == namespace)
+    #
+    #     if resource_type is not None:
+    #         tests.append(lambda k, v: k.resource_type == resource_type)
+    #
+    #     if name is not None:
+    #         tests.append(lambda k, v: k.name == name)
+    #
+    #     for key, resource in self.resource_map.items():
+    #         if all(test(key, resource) for test in tests):
+    #             yield resource
+
+    @classmethod
+    def resource_key(cls, resource: kube.Resource) -> Hashable:
+        return cls.make_key(type(resource), resource.name, resource.namespace)
+
+    @classmethod
+    def make_key(
+            cls,
+            resource_type: Type[kube.Resource],
+            name: str,
+            namespace: Any=DEFAULT,
+    ) -> ResourceKey:
+        if namespace is DEFAULT:
+            namespace = 'default'
+        return cls.ResourceKey(namespace, resource_type, name)
+
+    @classmethod
+    def add_resource(cls, resource, overwrite=False):
+        key = cls.make_key(type(resource), resource.name, resource.namespace)
+        if not overwrite and key in cls.resource_map:
+            raise AssertionError(
+                f'An object with the key {key!r} already exists in the '
+                f'resource map')
+        _logger.debug('MockKubernetes.add_resource', resource=resource)
+        cls.resource_map[key] = resource
+
+    @classmethod
+    @contextlib.contextmanager
+    def patch(cls, resources: Iterable[kube.Resource]):
+        try:
+            for resource in resources:
+                cls.add_resource(resource)
+
+            patch_kubernetes = mock.patch(
+                'k8s_snapshots.kube.Kubernetes',
+                cls
+            )
+            with patch_kubernetes:
+                yield
+        finally:
+            cls.resource_map.clear()
+
+
+@contextlib.contextmanager
+def mock_kube(resources: Iterable[kube.Resource]):
+    """
+    Mock the resources available through the `k8s_snapshots.kube.Kubernetes`
+    abstraction.
+
+    Parameters
+    ----------
+    resources
+
+    Returns
+    -------
+    The `k8s_snapshots.kube.Kubernetes` mock
+
+    """
+    with MockKubernetes.patch(resources):
+        yield
+
+
+def make_resource(
+        resource_type: Type[kube.Resource],
+        name,
+        namespace=DEFAULT,
+        labels=DEFAULT,
+        annotations=DEFAULT,
+        resource_spec=DEFAULT,
+) -> kube.Resource:
+    """
+    Create a Kubernetes Resource.
+    """
+
+    if namespace is DEFAULT:
+        namespace = 'default'
+
+    if annotations is DEFAULT:
+        annotations = {}
+
+    api = MagicMock(
+        spec=pykube.HTTPClient,
+        config=Mock()
+    )
+
+    if resource_spec is DEFAULT:
+        resource_spec = {}
+
+    obj = {
+        'metadata': {
+            'name': name,
+            'annotations': annotations,
+            'selfLink': f'test/{namespace}/{resource_type.endpoint}/{name}'
+        },
+        'spec': resource_spec,
+    }
+
+    if labels is not DEFAULT:
+        obj['metadata']['labels'] = labels
+    if namespace is not DEFAULT:
+        obj['metadata']['namespace'] = namespace
+
+    return resource_type(api, obj)
+
+
+def make_volume_and_claim(
+        ctx,
+        volume_name='test-pv',
+        claim_name='test-pvc',
+        volume_annotations=DEFAULT,
+        claim_annotations=DEFAULT,
+        claim_namespace=DEFAULT,
+        volume_zone_label=DEFAULT,
+) -> Tuple[kube.Resource, kube.Resource]:
+    """
+    Creates
+
+    """
+    if volume_zone_label is DEFAULT:
+        volume_zone_label = {LABEL_ZONE_KEY: LABEL_ZONE_VALUE}
+
+    pv = make_resource(
+        pykube.objects.PersistentVolume,
+        volume_name,
+        annotations=volume_annotations,
+        labels=volume_zone_label,
+        resource_spec={
+            'claimRef': {
+                'name': claim_name,
+                'namespace': claim_namespace,
+            },
+            'gcePersistentDisk': {
+                'pdName': 'test-pd'
+            }
+        }
+    )
+
+    pvc = make_resource(
+        pykube.objects.PersistentVolumeClaim,
+        claim_name,
+        annotations=claim_annotations,
+        namespace=claim_namespace,
+        resource_spec={
+            'volumeName': volume_name,
+        }
+    )
+
+    return pv, pvc
+
+
+@pytest.fixture
+def fx_volume_zone_label(request):
+    return {LABEL_ZONE_KEY: LABEL_ZONE_VALUE}
+
+
+@pytest.fixture
+def fx_volume_annotation_provisioned_by(request) -> Dict[str, str]:
+    return {ANNOTATION_PROVISIONED_BY_KEY: ANNOTATION_PROVISIONED_BY_VALUE}
+
+
+@pytest.fixture
+def fx_annotation_deltas(request):
+    deltas = request.getfixturevalue('fx_deltas')
+    context = request.getfixturevalue('fx_context')
+    return {
+        context.config['deltas_annotation_key']: deltas
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ import pytest
 import contextlib
 import datetime
 import k8s_snapshots.config
-from k8s_snapshots.logconf import configure_logging
+from k8s_snapshots.logconf import configure_from_config
 from k8s_snapshots.config import read_volume_config
 
 
@@ -11,7 +11,7 @@ from k8s_snapshots.config import read_volume_config
 def setup_logging():
     os.environ['GCLOUD_PROJECT'] = 'foo'
     config = k8s_snapshots.config.from_environ()
-    configure_logging(config)
+    configure_from_config(config)
 
 
 @contextlib.contextmanager
@@ -39,7 +39,8 @@ def set_env(**environ):
 
 
 class TestManualVolumes:
-    """Test finding the manual list of volumes.
+    """
+    Test finding the manual list of volumes.
     """
 
     def test_find_volumes(self):
@@ -53,12 +54,11 @@ class TestManualVolumes:
             rules = read_volume_config()['rules']
             assert len(rules) == 2
             assert rules[0].name == 'foo'
-            assert rules[0].namespace == ''
+            assert rules[0].source is None
             assert rules[0].deltas == [datetime.timedelta(1), datetime.timedelta(7)]
             assert rules[0].gce_disk == 'foo'
             assert rules[1].name == 'bar'
-            assert rules[1].namespace == ''
+            assert rules[1].source is None
             assert rules[1].deltas == [datetime.timedelta(1), datetime.timedelta(2)]
             assert rules[1].gce_disk == 'bar'
             assert rules[1].gce_disk_zone == 'eu-west-1'
-            assert rules[1].claim_name == ''

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,16 +2,7 @@ import os
 import pytest
 import contextlib
 import datetime
-import k8s_snapshots.config
-from k8s_snapshots.logconf import configure_from_config
 from k8s_snapshots.config import read_volume_config
-
-
-@pytest.fixture(autouse=True, scope='session')
-def setup_logging():
-    os.environ['GCLOUD_PROJECT'] = 'foo'
-    config = k8s_snapshots.config.from_environ()
-    configure_from_config(config)
 
 
 @contextlib.contextmanager
@@ -46,9 +37,9 @@ class TestManualVolumes:
     def test_find_volumes(self):
         with set_env(**{
             'VOLUMES': 'foo,bar',
-            'VOLUME_FOO_DELTAS': '1d 7d',
+            'VOLUME_FOO_DELTAS': 'P1D P7D',
             'VOLUME_FOO_ZONE': 'eu-central-1',
-            'VOLUME_BAR_DELTAS': '1d 2d',
+            'VOLUME_BAR_DELTAS': 'P1D P2D',
             'VOLUME_BAR_ZONE': 'eu-west-1',
         }):
             rules = read_volume_config()['rules']

--- a/tests/test_kube.py
+++ b/tests/test_kube.py
@@ -1,0 +1,36 @@
+import pykube
+
+from k8s_snapshots import kube
+from tests.fixtures.kube import mock_kube
+
+
+def test_mock_kube(fx_context):
+    n_resources = 5
+    volume_names = [f'test-volume-{i}' for i in range(0, n_resources)]
+
+    def _volume(name, namespace='default'):
+        return pykube.objects.PersistentVolume(
+            fx_context.kube_client(),
+            {
+                'apiVersion': 'v1',
+                'kind': 'PersistentVolume',
+                'metadata': {
+                    'name': name,
+                },
+            }
+        )
+
+    resources = [_volume(volume_name) for volume_name in volume_names]
+
+    with mock_kube(resources) as _kube:
+        for expected_resource, volume_name in zip(resources, volume_names):
+            assert expected_resource.name == volume_name, \
+                'Resources was not ceated properly'
+            kube_resource = kube.get_resource_or_none_sync(
+                fx_context.kube_client(),
+                pykube.objects.PersistentVolume,
+                name=volume_name
+            )
+            assert kube_resource == expected_resource
+
+            assert len(kube_resource.name)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,15 +1,53 @@
+from unittest import mock
+
 import pytest
 from unittest.mock import MagicMock
-from k8s_snapshots.rule import rule_from_pv
-from k8s_snapshots.errors import AnnotationError
-from pykube.objects import PersistentVolume
+from k8s_snapshots.rule import rule_from_pv, Rule, parse_deltas
+from k8s_snapshots.errors import UnsupportedVolume
 
 
-class TestRuleFromPV:
-    def test_fails_if_no_zone(self):
+@pytest.fixture
+def fx_deltas():
+    return parse_deltas('PT1M P1D')
 
-        v = MagicMock(annotations={
-            'pv.kubernetes.io/provisioned-by': 'kubernetes.io/gce-pd'
-        }, labels={})
-        with pytest.raises(AnnotationError):
-            rule_from_pv(volume=v, api=None, deltas_annotation_key='test')
+
+def make_pv(
+        name='fake-pv',
+        deltas_annotation='PT1M P1D',
+        claim_name='fake-pvc'
+) -> MagicMock:
+
+    if deltas_annotation is not None:
+        annotations = {
+
+        }
+
+    return MagicMock(
+        obj={
+            'metadata': {
+                'name': name,
+            },
+            'spec': {
+                'claimRef': {
+                    'name': claim_name
+                }
+            }
+        }
+    )
+
+
+def test_fails_if_no_zone(fx_deltas):
+    v = MagicMock(annotations={
+        'pv.kubernetes.io/provisioned-by': 'kubernetes.io/gce-pd'
+    }, labels={})
+    with pytest.raises(UnsupportedVolume):
+        Rule.from_volume(volume=v, source=v, deltas=fx_deltas)
+
+
+@pytest.mark.skip
+def test_rule_from_volume():
+    pv = MagicMock(
+        metadata=[]
+    )
+    pass
+

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,53 +1,187 @@
-from unittest import mock
+import asyncio
 
+import pykube
 import pytest
-from unittest.mock import MagicMock
-from k8s_snapshots.rule import rule_from_pv, Rule, parse_deltas
-from k8s_snapshots.errors import UnsupportedVolume
+
+from k8s_snapshots import errors
+from k8s_snapshots.context import Context
+from k8s_snapshots.core import volume_from_resource
+from k8s_snapshots.rule import rule_from_pv
+from tests.fixtures.kube import (
+    mock_kube,
+    make_volume_and_claim,
+    ANNOTATION_PROVISIONED_BY,
+    make_resource,
+    LABEL_ZONE
+)
+
+@pytest.mark.parametrize(
+    ['deltas_annotation_key'],
+    [
+        pytest.param(
+            'test-snapshots.kubernetes.io/deltas',
+            id='cfg_annotation_key_0',
+        ),
+        pytest.param(
+            'foo/deltas',
+            id='cfg_annotation_key_1',
+        )
+    ]
+)
+@pytest.mark.parametrize(
+    ['volume_zone_label', 'provisioner_annotation'],
+    [
+        pytest.param(
+            LABEL_ZONE,
+            ANNOTATION_PROVISIONED_BY,
+            id='zone_label_present_annotation_provisioned_by_present'
+        ),
+        pytest.param(
+            {},
+            ANNOTATION_PROVISIONED_BY,
+            id='zone_label_absent_annotation_provisioned_by_present',
+            marks=pytest.mark.xfail(
+                reason='Missing zone label',
+                raises=errors.UnsupportedVolume,
+                strict=True
+            )
+        ),
+        pytest.param(
+            LABEL_ZONE,
+            {},
+            id='zone_label_present_annotation_provisioned_by_absent',
+            marks=pytest.mark.xfail(
+                reason='Missing provisioner annotation',
+                raises=errors.UnsupportedVolume,
+                strict=True,
+            )
+        ),
+    ]
+)
+def test_rule_from_volume_with_claim(
+        deltas_annotation_key,
+        fx_deltas,
+        volume_zone_label,
+        provisioner_annotation,
+):
+    ctx = Context({
+        'deltas_annotation_key': deltas_annotation_key
+    })
+    pv, pvc = make_volume_and_claim(
+        ctx=ctx,
+        volume_annotations=provisioner_annotation,
+        claim_annotations={
+            ctx.config['deltas_annotation_key']: fx_deltas,
+        },
+        volume_zone_label=volume_zone_label,
+    )
+
+    loop = asyncio.get_event_loop()
+    with mock_kube([pv, pvc]) as _mocked:
+        deltas_annotation_key = ctx.config['deltas_annotation_key']
+        rule = loop.run_until_complete(
+            rule_from_pv(
+                ctx,
+                pv,
+                deltas_annotation_key
+            )
+        )
+        assert rule.source == pvc.obj['metadata']['selfLink']
+        assert deltas_annotation_key in pvc.annotations
 
 
-@pytest.fixture
-def fx_deltas():
-    return parse_deltas('PT1M P1D')
+@pytest.mark.parametrize(
+    ['claim_namespace'],
+    [
+        pytest.param('default'),
+        pytest.param('test-namespace'),
+    ]
+)
+def test_rule_name_from_pvc(fx_context, claim_namespace):
+    claim_name = 'source-pvc'
 
-
-def make_pv(
-        name='fake-pv',
-        deltas_annotation='PT1M P1D',
-        claim_name='fake-pvc'
-) -> MagicMock:
-
-    if deltas_annotation is not None:
-        annotations = {
-
-        }
-
-    return MagicMock(
-        obj={
-            'metadata': {
-                'name': name,
+    source_pv = make_resource(
+        pykube.objects.PersistentVolume,
+        'source-pv',
+        annotations=ANNOTATION_PROVISIONED_BY,
+        labels=LABEL_ZONE,
+        resource_spec={
+            'claimRef': {
+                'name': claim_name,
+                'namespace': claim_namespace,
             },
-            'spec': {
-                'claimRef': {
-                    'name': claim_name
-                }
+            'gcePersistentDisk': {
+                'pdName': 'source-pd',
             }
         }
     )
 
-
-def test_fails_if_no_zone(fx_deltas):
-    v = MagicMock(annotations={
-        'pv.kubernetes.io/provisioned-by': 'kubernetes.io/gce-pd'
-    }, labels={})
-    with pytest.raises(UnsupportedVolume):
-        Rule.from_volume(volume=v, source=v, deltas=fx_deltas)
-
-
-@pytest.mark.skip
-def test_rule_from_volume():
-    pv = MagicMock(
-        metadata=[]
+    source_pvc = make_resource(
+        pykube.objects.PersistentVolumeClaim,
+        claim_name,
+        namespace=claim_namespace,
+        annotations={
+            fx_context.config['deltas_annotation_key']: 'PT1M PT2M'
+        }
     )
-    pass
+
+    resources = [source_pv, source_pvc]
+
+    if claim_namespace == 'default':
+        expected_rule_name = f'pvc-{claim_name}'
+    else:
+        expected_rule_name = f'{claim_namespace}-pvc-{claim_name}'
+
+    loop = asyncio.get_event_loop()
+    with mock_kube(resources):
+        async def _run():
+            rule = await rule_from_pv(
+                ctx=fx_context,
+                volume=source_pv,
+                deltas_annotation_key=fx_context.config['deltas_annotation_key']
+            )
+
+            assert rule.name == expected_rule_name
+
+        loop.run_until_complete(_run())
+
+
+def test_rule_name_from_pv(
+        fx_context,
+        fx_volume_zone_label,
+        fx_volume_annotation_provisioned_by,
+        fx_annotation_deltas,
+):
+    volume_name = 'source-pv'
+
+    annotations = {}
+    annotations.update(fx_volume_annotation_provisioned_by)
+    annotations.update(fx_annotation_deltas)
+
+    source_pv = make_resource(
+        pykube.objects.PersistentVolume,
+        volume_name,
+        annotations=annotations,
+        labels=fx_volume_zone_label,
+        resource_spec={
+            'gcePersistentDisk': {
+                'pdName': 'source-pd'
+            }
+        }
+    )
+
+    expected_rule_name = f'pv-{volume_name}'
+
+    loop = asyncio.get_event_loop()
+    with mock_kube([source_pv]):
+        async def _run():
+            rule = await rule_from_pv(
+                ctx=fx_context,
+                volume=source_pv,
+                deltas_annotation_key=fx_context.config['deltas_annotation_key']
+            )
+
+            assert rule.name == expected_rule_name
+
+        loop.run_until_complete(_run())
 

--- a/tests/test_volume_from_resources.py
+++ b/tests/test_volume_from_resources.py
@@ -1,0 +1,130 @@
+import asyncio
+
+import pytest
+import pykube
+
+from k8s_snapshots import errors
+from k8s_snapshots.core import volume_from_resource
+from tests.fixtures import make_resource
+from tests.fixtures.kube import mock_kube
+
+PV_RESOURCE = make_resource(
+    pykube.objects.PersistentVolume,
+    'test-pv',
+)
+
+
+@pytest.mark.parametrize(
+    [
+        'resource',  # resource to get volume from
+        'resources',  # resources in mocked kube
+        'expected_volume_index',  # index in 'resources' for the expected volume
+    ],
+    [
+        pytest.param(
+            PV_RESOURCE,
+            [PV_RESOURCE],
+            0,
+            id='valid_from_volume'
+        ),
+        pytest.param(
+            make_resource(
+                pykube.objects.PersistentVolumeClaim,
+                'test-pvc',
+                resource_spec={
+                    'volumeName': 'correct-pv'
+                }
+            ),
+            [
+                make_resource(
+                    pykube.objects.PersistentVolume,
+                    'incorrect-pv',
+                ),
+                make_resource(
+                    pykube.objects.PersistentVolume,
+                    'correct-pv',
+                ),
+            ],
+            1,
+            id='valid_from_volume_claim'
+        ),
+        pytest.param(
+            make_resource(
+                pykube.objects.PersistentVolumeClaim,
+                'test-pvc',
+                resource_spec={
+                    'volumeName': 'nonexistent-pv'
+                }
+            ),
+            [
+                make_resource(
+                    pykube.objects.PersistentVolume,
+                    'existing-but-different-pv'
+                )
+            ],
+            None,
+            id='no_volume_for_claim',
+            marks=pytest.mark.xfail(
+                reason='Volume referred by claim\'s .spec.volumeName does not '
+                       'exist',
+                raises=errors.VolumeNotFound,
+                strict=True,
+            )
+        ),
+        pytest.param(
+            make_resource(
+                pykube.objects.PersistentVolumeClaim,
+                'claim-without-spec-volumename',
+                resource_spec={},
+            ),
+            [],
+            None,
+            id='claim_without_spec_volumeName',
+            marks=pytest.mark.xfail(
+                reason='Invalid claim spec, missing .spec.volumeName',
+                raises=errors.VolumeNotFound,
+                strict=True,
+            )
+        ),
+        pytest.param(
+            make_resource(
+                pykube.objects.Deployment,
+                'a-deployment-is-not-a-volume',
+                resource_spec={
+                    'volumeName': 'test-pv'
+                }
+            ),
+            [
+                make_resource(
+                    pykube.objects.PersistentVolume,
+                    'test-pv'
+                )
+            ],
+            None,
+            id='invalid_resource_can_not_get_volume',
+            marks=pytest.mark.xfail(
+                reason='Invalid resource type',
+                raises=errors.VolumeNotFound,
+                strict=True,
+            )
+        )
+    ]
+)
+def test_volume_from_resource(
+        fx_context,
+        resource,
+        resources,
+        expected_volume_index,
+):
+    loop = asyncio.get_event_loop()
+
+    with mock_kube(resources):
+        result = loop.run_until_complete(
+            volume_from_resource(
+                ctx=fx_context,
+                resource=resource,
+            )
+        )
+
+        if expected_volume_index is not None:
+            assert result == resources[expected_volume_index]


### PR DESCRIPTION
## ISO 8601 duration and snapshot labels

Improvements:

- Use `Rule.__structlog__()` instead of a custom processor for Rule. Run
  value.`<obj>.__structlog__()` when extracting values from key_hints. Enables
  you to reference fields via key_hints without having a too early
  serialization step.
- Add and fix key_hints for Rule.* events in `detenmine_next_snapshot()`
- Add heartbeat event
- Differentiate between the createSnapshot `operation` resource and the
  `snapshot` resource in `make_backup()`
- Rename `Context.make_gclient()` to `Context.gcloud()`, remove
  `Context.gcloud` pre-set instance to avoid re-using unthreadsafe
  resource.

BREAKING:

- Use ISO 8601 duration format for logging and deltas.
  Ensures cross-language compatibility.
- Move "`Rule` from PV" creation into `Rule.from_volume`.
- Base snapshot name on
  `{short_kind[source.kind}}{source.metadata.namespace}{source.metadata.name}{timestamp}`,
  e.g `pvc-my-namespace-my-pvc-12345`.
- Add "author label", e.g.:
  ```json
  {"created-by": "k8s-snapshots"}
  ```
  to new GCE Snapshots. See [Labeling Resources][0]
- Filter by author label when loading snapshots for expiration and
  scheduling of next snapshot. Provides isolation of k8s-snapshots
  snapshots from other snapshots.
- Add configuration of the "author label" mentioned above.

[0]: https://cloud.google.com/compute/docs/labeling-resources

## Watch both PV and PVC resources

Improvements:

- Watch both PersistentVolume and PersistentVolumeClaim resources.
- Refactor logging configuration to allow easy custom logging setup,
  e.g. in tests.

Refactor:
- Create async wrappers for pykube watching and resource getting.
- Move snapshot-related functions to k8s_snapshots.snapshot.

## Add Kubernetes testing

Improvements:

- Added fixtures and mocking helpers for Kubernetes.
