### PR TITLE
Add RBAC docs and manifest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ has permissions to create snapshots. See below more more on the
 available configuration options.
 
 
-How do enable backups
+How to enable backups
 ---------------------
 
 To backup a volume, you should add an annotation with the name
@@ -199,6 +199,13 @@ Currently, we will try to connect with the default credentials.
 The region is usually detected via the meta data service. If that is not
 the case, you can set `AWS_REGION`.
 
+### For Role-based Access Control (RBAC) enabled clusters
+
+In kubernetes clusters with RBAC, the required permissions need to be provided to the `k8s-snapshots` pods to watch and list `persistentvolume` or `persistentvolumeclaims`.
+
+  ```
+    kubectl apply -f rbac.yaml
+  ```
 
 ### Pinging a third party service
 

--- a/rbac.yaml
+++ b/rbac.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: k8s-snapshots
+  name: k8s-snapshots
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: k8s-snapshots
+  name: k8s-snapshots
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - "k8s-snapshots.elsdoerfer.com"
+    resources:
+      - snapshotrules
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - persistentvolumeclaims
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: k8s-snapshots
+  name: k8s-snapshots
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-snapshots
+subjects:
+  - kind: ServiceAccount
+    name: k8s-snapshots
+    namespace: kube-system
+


### PR DESCRIPTION
While configuring `k8s-snapshots` project in our kubernetes cluster where RBAC was enabled leading to behavior where `k8s-snapshots` didn't have required permissions. This PR will add a section to README.md for RBAC and also add the manifest file for `k8s-snapshots` to work. As I'm still learning about how RBAC works in kubernetes, I have added the rbac file that works for us, feel free to comment suggest ways to reduce permissions or adjust the docs. 

Feedback is appreciated. :)