### PR TITLE
Upgrade to boto3 for using http proxy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ isodate==0.5.4
 python-dateutil==2.6.0
 aiohttp==2.2.2
 aiostream==0.2.4
-boto==2.48.0
+boto3==1.5.25


### PR DESCRIPTION
When using k8s-snapshots through http proxy, it cannot connect to amazon ec2 endpoint because [boto](https://github.com/boto/boto) doesn't support http proxy on python3.x (see https://github.com/boto/boto/pull/2718). Upgrading to [boto3](https://github.com/boto/boto3) fixes this problem.
