### PR TITLE
Re-open k8s watches that close successfully

### DIFF
--- a/k8s_snapshots/kube.py
+++ b/k8s_snapshots/kube.py
@@ -174,13 +174,16 @@ async def _watch_resources_thread_wrapper(
     def worker():
         try:
             _log.debug('watch-resources.worker.start')
-            sync_iterator = watch_resources_sync(
-                client_factory=client_factory,
-                resource_type=resource_type
-            )
-            for event in sync_iterator:
-                # only put_nowait seems to cause SIGSEGV
-                loop.call_soon_threadsafe(channel.put_nowait, event)
+            while True:
+                sync_iterator = watch_resources_sync(
+                    client_factory=client_factory,
+                    resource_type=resource_type
+                )
+                _log.debug('watch-resources.worker.watch-opened')
+                for event in sync_iterator:
+                    # only put_nowait seems to cause SIGSEGV
+                    loop.call_soon_threadsafe(channel.put_nowait, event)
+                _log.debug('watch-resources.worker.watch-closed')
         except pykube.exceptions.HTTPError as e:
             # TODO: It's possible that the user creates the resource
             # while we are already running. We should pick this up


### PR DESCRIPTION
When a watch finishes (without errors), this indicates the API server
closed the connection, eg. because it's shutting down.

We do not want to stop watching in this case, so we re-open a new
connection and continue watching. This will result in re-processing
everything, which is fine.

This prevents a condition where the watch returns, resulting in a state
where the process no longer responds to any kubernetes changes,
preventing new snapshot rules from being picked up.

Fixes https://github.com/miracle2k/k8s-snapshots/issues/62

I suspect it may also fix the root cause of https://github.com/miracle2k/k8s-snapshots/issues/27