### PR TITLE
Pin yarl version to 1.1.1 to avoid incompatability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ python-dateutil==2.6.0
 aiohttp==2.2.2
 aiostream==0.2.4
 boto3==1.5.25
+yarl==1.1.1


### PR DESCRIPTION
Yarl 1.2 made a change that is incompatible with our version of aiohttp,
resulting in an error like "TypeError: Inheritance a class <class 'aiohttp.http_writer.URL'> from URL is for
bidden".