### PR TITLE
Discard scheduled snapshots that are no longer required

### DIFF
--- a/k8s_snapshots/snapshot.py
+++ b/k8s_snapshots/snapshot.py
@@ -406,10 +406,14 @@ def filter_snapshots_by_rule(snapshots: List[Snapshot], rule: Rule) -> Iterable[
     return filter(match_disk, snapshots)
 
 
-async def is_snapshot_required(ctx: Context, rule: Rule):
+def is_snapshot_required(ctx: Context, rule: Rule):
     backend = get_backend_for_rule(ctx, rule)
-    all_snapshots = await load_snapshots(ctx, {backend})
-    snapshot_times = get_snapshot_times_for_rule(all_snapshots, rule)
+    all_snapshots = load_snapshots(ctx, {backend})
+    return snapshots_for_rule_are_outdated(rule, all_snapshots)
+
+
+def snapshots_for_rule_are_outdated(rule: Rule, existing_snapshots):
+    snapshot_times = get_snapshot_times_for_rule(existing_snapshots, rule)
 
     if not snapshot_times:
         return True

--- a/k8s_snapshots/snapshot.py
+++ b/k8s_snapshots/snapshot.py
@@ -406,13 +406,13 @@ def filter_snapshots_by_rule(snapshots: List[Snapshot], rule: Rule) -> Iterable[
     return filter(match_disk, snapshots)
 
 
-def is_snapshot_required(ctx: Context, rule: Rule):
+async def is_snapshot_required(ctx: Context, rule: Rule):
     backend = get_backend_for_rule(ctx, rule)
-    all_snapshots = load_snapshots(ctx, {backend})
+    all_snapshots = await load_snapshots(ctx, {backend})
     return snapshots_for_rule_are_outdated(rule, all_snapshots)
 
 
-def snapshots_for_rule_are_outdated(rule: Rule, existing_snapshots):
+def snapshots_for_rule_are_outdated(rule: Rule, existing_snapshots: List[Snapshot]):
     snapshot_times = get_snapshot_times_for_rule(existing_snapshots, rule)
 
     if not snapshot_times:

--- a/k8s_snapshots/snapshot.py
+++ b/k8s_snapshots/snapshot.py
@@ -33,7 +33,7 @@ async def expire_snapshots(ctx, rule: Rule):
     backend = get_backend_for_rule(ctx, rule)
 
     snapshots_objects = filter_snapshots_by_rule(
-        await load_snapshots(ctx, [backend]), rule)
+        await load_snapshots(ctx, {backend}), rule)
     snapshots_with_date = {s: s.created_at for s in snapshots_objects}
 
     to_keep = expire(snapshots_with_date, rule.deltas)
@@ -204,7 +204,6 @@ async def poll_for_status(
         -   An awaitable for the new version of the resource.
     retry_for
         A list of statuses to retry for.
-    status_key
     sleep_time
         The time, in seconds, to sleep for between calls.
 
@@ -331,7 +330,7 @@ async def get_snapshots(ctx: Context, rulesgen, reload_trigger):
     )
 
     async for item in combined:
-        # Figure out a se of backends that are in use with the rules
+        # Figure out a set of backends that are in use with the rules
         backends = set()
         for rule in item['rules']:
             backends.add(get_backend_for_rule(ctx, rule))
@@ -364,13 +363,7 @@ def determine_next_snapshot(snapshots, rules):
 
     for rule in rules:
         _log = _logger.new(rule=rule)
-        # Find all the snapshots that match this rule
-        snapshots_for_rule = filter_snapshots_by_rule(snapshots, rule)
-        # Rewrite the list to snapshot
-        snapshot_times = map(lambda s: s.created_at, snapshots_for_rule)
-        # Sort by timestamp
-        snapshot_times = sorted(snapshot_times, reverse=True)
-        snapshot_times = list(snapshot_times)
+        snapshot_times = get_snapshot_times_for_rule(snapshots, rule)
 
         # There are no snapshots for this rule; create the first one.
         if not snapshot_times:
@@ -397,7 +390,29 @@ def determine_next_snapshot(snapshots, rules):
     return next_rule, next_timestamp
 
 
-def filter_snapshots_by_rule(snapshots: List[Snapshot], rule) -> Iterable[Snapshot]:
+def get_snapshot_times_for_rule(snapshots: List[Snapshot], rule: Rule):
+    # Find all the snapshots that match this rule
+    snapshots_for_rule = filter_snapshots_by_rule(snapshots, rule)
+    # Rewrite the list to snapshot
+    snapshot_times = map(lambda s: s.created_at, snapshots_for_rule)
+    # Sort by timestamp
+    snapshot_times = sorted(snapshot_times, reverse=True)
+    return list(snapshot_times)
+
+
+def filter_snapshots_by_rule(snapshots: List[Snapshot], rule: Rule) -> Iterable[Snapshot]:
     def match_disk(snapshot: Snapshot):
         return snapshot.disk == rule.disk
     return filter(match_disk, snapshots)
+
+
+async def is_snapshot_required(ctx: Context, rule: Rule):
+    backend = get_backend_for_rule(ctx, rule)
+    all_snapshots = await load_snapshots(ctx, {backend})
+    snapshot_times = get_snapshot_times_for_rule(all_snapshots, rule)
+
+    if not snapshot_times:
+        return True
+
+    next_snapshot_time = snapshot_times[0] + rule.deltas[0]
+    return next_snapshot_time < pendulum.now('utc')

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,0 +1,47 @@
+from datetime import timedelta
+from pendulum import Pendulum
+from unittest import TestCase
+
+from k8s_snapshots.backends.abstract import Snapshot
+from k8s_snapshots.context import Context
+from k8s_snapshots.rule import Rule
+from k8s_snapshots.snapshot import snapshots_for_rule_are_outdated
+
+
+class TestSnapshotsAreUpToDate(TestCase):
+    TEST_DISK = 'test-disk'
+
+    def setUp(self):
+        self.mock_context = Context({})
+        self.rule = Rule(
+            name='test_rule',
+            deltas=[timedelta(hours=1), timedelta(days=30)],
+            backend='test_backend',
+            disk=self.TEST_DISK)
+
+    def test_snapshot_is_required_without_existing_snapshots(self):
+        assert snapshots_for_rule_are_outdated(self.rule, [])
+
+    def test_snapshot_not_required_with_recent_snapshots(self):
+        assert not snapshots_for_rule_are_outdated(self.rule, [
+            Snapshot(
+                created_at=Pendulum.now('utc') - timedelta(minutes=59),
+                name='snapshot-1',
+                disk=self.TEST_DISK)
+        ])
+
+    def test_snapshot_required_with_outdated_snapshot(self):
+        assert snapshots_for_rule_are_outdated(self.rule, [
+            Snapshot(
+                created_at=Pendulum.now('utc') - timedelta(hours=1, minutes=1),
+                name='snapshot-1',
+                disk=self.TEST_DISK)
+        ])
+
+    def test_snapshot_required_with_snapshot_for_different_disk(self):
+        assert snapshots_for_rule_are_outdated(self.rule, [
+            Snapshot(
+                created_at=Pendulum.now('utc') - timedelta(minutes=5),
+                name='snapshot-1',
+                disk='some-other-disk')
+        ])


### PR DESCRIPTION
We are using k8s-snapshots in multiple clusters where it is responsible for the snapshots of up-to 7 different volumes at a time. We also run a custom cronjob in the cluster that periodically mounts the latest snapshots to create tar-files for persistent backups.

With this setup we experienced the following problem: The persistent volumes created by our tar-uploader created a lot of volume and pvc-events which each led to a backup being scheduled. Since multiple of the cronjobs ran at once this meant that the same backup was being scheduled for each backup. The backuper-task then ran in circles creating and immediately expiring backups for the same volume.
Since each created backup again triggered another backup and on each loop of the backuper only one scheduled backup was pulled the queue was never emptied again and kept increasing.

Our solution to the problem is to check whether a backup is still required each time before actually calling `make_backup`. Unfortunately this requires another query to the snapshots-api, but I think this is tolerable compared to the api-call for performing the actual backup (and if one considers the extra work of performing the same backup twice due to duplicate scheduling one even performs less work).

This should allso fix https://github.com/miracle2k/k8s-snapshots/issues/28

Before I end: Thanks for providing this very useful tool on github! This saved us a lot of work end even though it took us some time to understand what actually happened inside the snapshotter, we found implementing the changes necessary to fix the issue for us very straightforward due to the nice structure in your repo 👍 

PS: I fixed some types and typos along the way, hope you don't mind.