### PR TITLE
Fix: Quickstart instructions now use the `dev` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
       - name: k8s-snapshots
-        image: elsdoerfer/k8s-snapshots:v2.0
+        image: elsdoerfer/k8s-snapshots:dev
 EOF
 ```
 


### PR DESCRIPTION
Fixes issue #80.
Note: publishing a `latest` version of the image would probably be clearer, and would make this conform with the rest of the ecosystem.