### PR TITLE
Automated publishing using drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,5 +21,4 @@ steps:
     when:
       ref:
         - refs/heads/master
-        - refs/heads/drone
         - refs/tags/*


### PR DESCRIPTION
@miracle2k not sure if you'd consider adding this and enabling with https://cloud.drone.io/ ?

All you would need to do is add DOCKER_USERNAME, DOCKER_PASSWORD, DOCKER_REPO to the secrets and it will auto publish from tags x.x.x (it also updates x and x.x version to what was matched)and master goes to latest

Here's the sample I have publishing 2.0.1 to https://hub.docker.com/r/pelotech/k8s-snapshots/tags which includes the defaults TZ fix PR #84 