### PR TITLE
Add support for regional volumes in GCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM python:3.6-alpine
 
 ADD . /app
 WORKDIR /app
-RUN pip install -r requirements.txt
-RUN python setup.py install
+RUN apk add --no-cache --virtual .build_deps gcc musl-dev \
+    && pip install -r requirements.txt \
+    && python setup.py install \
+    && apk del .build_deps gcc musl-dev
 ENV TZ UTC
+
 CMD ["k8s-snapshots"]

--- a/k8s_snapshots/snapshot.py
+++ b/k8s_snapshots/snapshot.py
@@ -365,9 +365,11 @@ def determine_next_snapshot(snapshots, rules):
     for rule in rules:
         _log = _logger.new(rule=rule)
         # Find all the snapshots that match this rule
+        # This returns a <filter> object
         snapshots_for_rule = filter_snapshots_by_rule(snapshots, rule)
-        # Rewrite the list to snapshot
-        snapshot_times = map(lambda s: s.created_at, snapshots_for_rule)
+
+        snapshot_times = [item.created_at for item in snapshots_for_rule]
+
         # Sort by timestamp
         snapshot_times = sorted(snapshot_times, reverse=True)
         snapshot_times = list(snapshot_times)


### PR DESCRIPTION
This adds supports for regional volumes and should still retain full support for normal zone volumes. 
We had to use gcc to get one of the wheel files to install correctly though and never did figure out why.