### PR TITLE
Change log level for AnnotationNotFound on PVCs to INFO

### DIFF
--- a/k8s_snapshots/core.py
+++ b/k8s_snapshots/core.py
@@ -267,7 +267,7 @@ async def rule_from_persistent_volume_claim(
         deltas = get_deltas(
             volume_claim.annotations, ctx.config.get('deltas_annotation_key'))
     except AnnotationNotFound as exc:
-        _log.exception(
+        _log.info(
             events.Annotation.NOT_FOUND,
             key_hints=['volume_claim.metadata.name'],
         )


### PR DESCRIPTION
This fix will make `k8s-snapshots` log `annotation.not-found` lines with severity `INFO` instead of `ERROR` for PVCs.

this is a fix proposal to https://github.com/miracle2k/k8s-snapshots/issues/109